### PR TITLE
Do not override shared global variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,9 @@ else  {
 	
 	try {
 		
-		var code = program.ns + "= function(){ return new Function();};";
         var file = null;
+		var code = "if(typeof(" + program.ns + ")==='undefined')" +
+		           program.ns + "=function(){ return new Function();};";
 		var files = fs.readdirSync(program.dir);
 		for (i in files) {
 			if (files[i].match(/^[^\.]*\.jst/g)) {


### PR DESCRIPTION
Now it is possible to split templates onto parts and load them on demand without worrying about namespacing.
