### PR TITLE
More robust anonymous substitution

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function convert(fileName, namespace){
 	var data = fs.readFileSync(path, program.encoding);
     var code = dot.template(data).toString();
     var header = namespace+"['"+fileName.replace('.jst','')+"'] = function(it)";
-    code = code.replace('function anonymous(it)', header)+";";
+    code = code.replace(/function anonymous\([^\)]+\)/, header)+";";
 	return code;
 }
 


### PR DESCRIPTION
For some reason, the version of doT on my Windows 10 box returns the anonymous function as "function anonymous(it\n/**/)" (yes, with a newline before the empty comment), so the simple string replace doesn't work and I end up with an empty JST object.  The regular expression catches everything in between the parens and so works for that case.
